### PR TITLE
[Bug] Fix Padding around WISE Logo in Nav Bar 

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -132,15 +132,12 @@ h6 {
 
 #header {
     height: 70px;
-    transition: all 0.5s;
     z-index: 997;
-    transition: all 0.5s;
-    padding: 20px 0;
+    padding: 15px 0;
     position: fixed;
     left: 0;
     top: 0;
     right: 0;
-    transition: all 0.5s;
     z-index: 997;
     background-color: rgba(255, 255, 255, 1);
 }
@@ -151,11 +148,6 @@ h6 {
     padding: 15px 0;
     background-color: #fff;
     box-shadow: 0px 0px 30px rgba(127, 137, 161, 0.3);
-}
-
-#header.header-scrolled #topbar,
-#header.header-pages #topbar {
-    display: none;
 }
 
 #header .logo h1 {

--- a/css/style.css
+++ b/css/style.css
@@ -175,7 +175,7 @@ h6 {
 }
 
 #header .logo img {
-    padding: 0;
+    padding: 5px;
     /* margin: 7px 0; */
     max-height: 40px;
 }


### PR DESCRIPTION
**Purpose**
- The WISE logo in the navigation bar has uneven padding, when landing on any page
- This issue is resolved when the page is scrolled, causing all the text in the navbar to readjust and the padding around the logo to be fixed

**Changes**
- This PR ensures that the WISE logo has even padding on all sides when the page initially loads, without requiring a scroll to correct the issue

_Before:_
![image](https://github.com/user-attachments/assets/c75899c1-c9f6-4e42-a79e-0935ec06a72a)
_After:_
![image](https://github.com/user-attachments/assets/53a11e10-4a60-448c-989b-ac4ca0b70791)


**Additional Info**
- #8 