### PR TITLE
[Bug] Fix the "Women in Science and Engineering" Title's Padding

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -225,6 +225,7 @@ h6 {
     width: 100%;
     margin-left: 0;
     margin-right: 0;
+    padding-right: 10px;
 }
 
 #intro .intro-info h2 {


### PR DESCRIPTION
**Purpose**
- The title current is missing padding, especially towards the right of the text

**Changes**
![image](https://github.com/user-attachments/assets/3702dd5f-3384-41bf-8b52-f48d92fb6315)

**Additional Info**
- #11 