### PR TITLE
[Documentation] Add Contribution Guide to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,36 @@
 
 https://wiseuoft.org
 
-## Editing the website:
 
-### Setting up the environment
-- Download VSCode
-- Get Live Server (extension) to update real time
+### Contribution Guide
+_If you are **not** a part of the WISE executive team and would like to propose contributions, we'd love to hear from you! While this is a club and not an open-source project, we welcome ideas and contributions from anyone interested._
 
-### For events:
+#### Pre-requisites
+Install [Visual Studio Code](https://code.visualstudio.com/) and the [Live Server](https://marketplace.visualstudio.com/items?itemName=ritwickdey.LiveServer) extension.
+
+#### Create and Develop on a Fork of `wise-main`
+1. Fork the `wise-main` repository
+2. Go to the forked repository and clone it to your local machine
+4. Create a new branch with your changes and complete your changes 
+6. Push your branch to your **forked** repository
+
+#### Opening a Pull Request to the Original `wise-main` Repository
+1. Go to your **forked** repository on Github
+2. With the new changes pushed, go to the "Pull Requests" tab and click "New Pull Request"
+3. In the `base repository` dropdown, select `WISE-UofT/wise-main`. In the `base` dropdown selection the branch you want to merge into, usually `main`
+4. In the `head respository` dropdown, select your forked repository name. In the `compare` dropdown, select the branch you just pushed 
+5. Select `Allow edits by maintainers`
+<img width="1077" alt="image" src="https://github.com/user-attachments/assets/29ff0a38-1368-4724-8fd6-13d2ea40552c">
+6. Add a title, description and click "Create Pull Request"
+
+#### Wait for Approval
+The VP of marketing can now see this PR in the original `wise-main` repo under the "Pull Requests" tab.
+
+### Notes
+#### Working on Events?
 1. Uncomment the template in events.html
 2. Create a new webpage (make a copy from the template.html file, or just link to EventBrite)
 3. Link to the event module
 
-### For websites:
+#### For websites:
 - Copy from template.html

--- a/README.md
+++ b/README.md
@@ -33,5 +33,5 @@ The VP of marketing can now see this PR in the original `wise-main` repo under t
 2. Create a new webpage (make a copy from the template.html file, or just link to EventBrite)
 3. Link to the event module
 
-#### For websites:
+#### Working on Websites?
 - Copy from template.html


### PR DESCRIPTION
**Purpose**
Add a section to the `README` that outlines the steps for contributing to the repository. This will help new contributors understand how to fork, clone, make changes and open a pull request.

**Changes**
- Add proposed guide 
- Add a note under the guide explaining who the audience of the guide is

Additional Info
- #7 
- **Question:** I was making a minor change to these notes when I noticed that they both refer to `template.html` which is a file that doesn't seem to exist in the repo. Would you know if its still there and I accidentally missed it or if its deletion was intentional? 
![image](https://github.com/user-attachments/assets/74605cf4-1a0f-436b-bb62-0d9e56e47d84)
