### PR TITLE
[Bug] Fix Nav Bar Dropdown Menu Glitches

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -309,13 +309,11 @@ h6 {
 }
 
 .main-nav .drop-down ul {
-    display: block;
+    display: none;
     position: absolute;
     left: 0;
     top: calc(100% - 30px);
     z-index: 99;
-    opacity: 0;
-    visibility: hidden;
     padding: 10px 0;
     background: #fff;
     box-shadow: 0px 0px 30px rgba(127, 137, 161, 0.25);
@@ -323,9 +321,8 @@ h6 {
 }
 
 .main-nav .drop-down:hover>ul {
-    opacity: 1;
+    display: block;
     top: 100%;
-    visibility: visible;
 }
 
 .main-nav .drop-down li {
@@ -359,9 +356,7 @@ h6 {
 }
 
 .main-nav .drop-down .drop-down:hover>ul {
-    opacity: 1;
-    top: 0;
-    left: 100%;
+    display: block;
 }
 
 .main-nav .drop-down .drop-down>a {


### PR DESCRIPTION
**Purpose**
Fix the dropdown menu glitches in the nar bar caused by adjacent dropdown items overlaping when hovered on.

https://github.com/user-attachments/assets/4b39f2c9-1350-43e1-a92e-0a41456f38b9

**Changes**
Originally, the dropdowns existed however they were hidden with `opacity: 0, visibility: 0` and had `display: block`. Since the intention here was to hide the dropdowns, I have removed  `opacity: 0, visibility: 0` and made `display: none`. So when the page initially loads, the dropdowns will still exist however they are not seen. In the previous version, the dropdowns existed however they were hidden with `opacity` and `visibility`.

Additionally, when the labels are **hovered** on, I have added `display: block` to "unhide" the dropdown menus and cleaned up a few styles that were not needed as a result of introducing `display: block` (ex: `opacity`).

https://github.com/user-attachments/assets/5a0444a0-67db-493a-8ef9-ff4e816f28b3

**Additional Info**
- #9